### PR TITLE
m3u related bug fixes

### DIFF
--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -139,11 +139,11 @@ namespace ArchiveCacheManager
                 {
                     List<string> multiDiscPaths = new List<string>();
 
-                    // Add current disc first (mimick LaunchBox's behavior)
+                    // Add current disc first (mimics LaunchBox behavior)
                     if (filePaths.TryGetValue(discInfo.ApplicationId, out var mainPath))
                         multiDiscPaths.Add(mainPath);
 
-                    // Add all other disc paths, sorted by disc number then original list order (mimick LaunchBox's behavior)
+                    // Add all other disc paths, sorted by disc number then original list order (mimics LaunchBox behavior)
                     multiDiscPaths.AddRange(
                         LaunchInfo.Game.Discs
                             .Select((d, i) => new { d.ApplicationId, d.Disc, Index = i }) // attach index for tie-breaking
@@ -153,15 +153,21 @@ namespace ArchiveCacheManager
                     );
 
                     string m3uPath = LaunchInfo.GetM3uPath(LaunchInfo.GetArchiveCachePath(discInfo.ApplicationId), discInfo.ApplicationId);
-                    try
+
+                    // Skip writing if the .m3u already exists — this can occur when multiple discs share the same
+                    // archive path, resulting in identical, non-unique files
+                    if (!File.Exists(m3uPath))
                     {
-                        File.WriteAllLines(m3uPath, multiDiscPaths);
-                        DiskUtils.SetFileReadOnly(m3uPath);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.Log(string.Format("Failed to save m3u file \"{0}\".", m3uPath), Logger.LogLevel.Exception);
-                        Logger.Log(e.ToString(), Logger.LogLevel.Exception);
+                        try
+                        {
+                            File.WriteAllLines(m3uPath, multiDiscPaths);
+                            DiskUtils.SetFileReadOnly(m3uPath);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Log(string.Format("Failed to save m3u file \"{0}\".", m3uPath), Logger.LogLevel.Exception);
+                            Logger.Log(e.ToString(), Logger.LogLevel.Exception);
+                        }
                     }
                 }
             }

--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -63,19 +63,19 @@ namespace ArchiveCacheManager
         /// <summary>
         /// Extract the archive to the cache. In the event of a cache error, archive will be extracted to LaunchBox's temp lcation.
         /// </summary>
-        public static void AddArchiveToCache(int? disc = null)
+        public static void AddArchiveToCache(string discApp = null)
         {
-            if (LaunchInfo.Game.MultiDisc && LaunchInfo.MultiDiscSupport && disc == null)
+            if (LaunchInfo.Game.MultiDisc && LaunchInfo.MultiDiscSupport && discApp == null)
             {
                 LaunchInfo.Extractor.ProgressDivisor = LaunchInfo.Game.TotalDiscs - LaunchInfo.GetDiscCountInCache();
 
                 int discIndex = 0;
                 foreach (var discInfo in LaunchInfo.Game.Discs)
                 {
-                    if (!LaunchInfo.GetArchiveInCache(discInfo.Disc))
+                    if (!LaunchInfo.GetArchiveInCache(discInfo.ApplicationId))
                     {
                         LaunchInfo.Extractor.ProgressOffset = (100 / LaunchInfo.Extractor.ProgressDivisor) * discIndex;
-                        AddArchiveToCache(discInfo.Disc);
+                        AddArchiveToCache(discInfo.ApplicationId);
                         discIndex++;
                     }
                 }
@@ -89,31 +89,31 @@ namespace ArchiveCacheManager
                 if (!string.IsNullOrEmpty(singleFile))
                 {
                     // Delete previous directory contents. Don't want a build up of old individually extracted files.
-                    DiskUtils.DeleteDirectory(LaunchInfo.GetArchiveCachePath(disc), true);
+                    DiskUtils.DeleteDirectory(LaunchInfo.GetArchiveCachePath(discApp), true);
                 }
 
-                DiskUtils.CreateFile(PathUtils.GetArchiveCacheExtractingFlagPath(LaunchInfo.GetArchiveCachePath(disc)));
-                ClearCacheSpace(LaunchInfo.GetSize(disc));
-                Logger.Log(string.Format("Extracting archive to \"{0}\".", LaunchInfo.GetArchiveCachePath(disc)));
+                DiskUtils.CreateFile(PathUtils.GetArchiveCacheExtractingFlagPath(LaunchInfo.GetArchiveCachePath(discApp)));
+                ClearCacheSpace(LaunchInfo.GetSize(discApp));
+                Logger.Log(string.Format("Extracting archive to \"{0}\".", LaunchInfo.GetArchiveCachePath(discApp)));
 
-                var result = LaunchInfo.Extractor.Extract(LaunchInfo.GetArchivePath(disc), LaunchInfo.GetArchiveCachePath(disc), singleFile.ToSingleArray());
+                var result = LaunchInfo.Extractor.Extract(LaunchInfo.GetArchivePath(discApp), LaunchInfo.GetArchiveCachePath(discApp), singleFile.ToSingleArray());
                 if (result)
                 {
-                    LaunchInfo.UpdateSizeFromCache(disc);
-                    LaunchInfo.SaveToCache(disc);
-                    DiskUtils.SetDirectoryContentsReadOnly(LaunchInfo.GetArchiveCachePath(disc));
-                    File.Delete(PathUtils.GetArchiveCacheExtractingFlagPath(LaunchInfo.GetArchiveCachePath(disc)));
+                    LaunchInfo.UpdateSizeFromCache(discApp);
+                    LaunchInfo.SaveToCache(discApp);
+                    DiskUtils.SetDirectoryContentsReadOnly(LaunchInfo.GetArchiveCachePath(discApp));
+                    File.Delete(PathUtils.GetArchiveCacheExtractingFlagPath(LaunchInfo.GetArchiveCachePath(discApp)));
                 }
                 else
                 {
                     Logger.Log("Extraction error, removing output files from cache.");
-                    DiskUtils.DeleteDirectory(LaunchInfo.GetArchiveCachePath(disc));
+                    DiskUtils.DeleteDirectory(LaunchInfo.GetArchiveCachePath(discApp));
                 }
             }
             else
             {
                 Logger.Log(@"Error creating or accessing cache location. Archive will be extracted to LaunchBox\ThirdParty\7-Zip\Temp.");
-                LaunchInfo.Extractor.Extract(LaunchInfo.GetArchivePath(disc), PathUtils.GetLaunchBox7zTempPath(), LaunchInfo.GetExtractSingleFile().ToSingleArray());
+                LaunchInfo.Extractor.Extract(LaunchInfo.GetArchivePath(discApp), PathUtils.GetLaunchBox7zTempPath(), LaunchInfo.GetExtractSingleFile().ToSingleArray());
             }
         }
 
@@ -121,18 +121,18 @@ namespace ArchiveCacheManager
         {
             if (LaunchInfo.Game.MultiDisc && LaunchInfo.MultiDiscSupport)
             {
-                Dictionary<int, string> filePaths = new Dictionary<int, string>();
+                Dictionary<string, string> filePaths = new Dictionary<string, string>();
 
                 foreach (var discInfo in LaunchInfo.Game.Discs)
                 {
-                    foreach (var m3uPath in LaunchInfo.GetAllM3uPaths(LaunchInfo.GetArchiveCachePath(discInfo.Disc)))
+                    foreach (var m3uPath in LaunchInfo.GetAllM3uPaths(LaunchInfo.GetArchiveCachePath(discInfo.ApplicationId)))
                     {
                         // Delete all previously generated m3u files regardless of current m3u name configuration.
                         // Keeps the cache folders clean from multiple m3u files when launching different discs,
                         // and prevents m3u files from being included in the subsequent archive listing.
                         DiskUtils.DeleteFile(m3uPath);
                     }
-                    filePaths.Add(discInfo.Disc, ListCacheArchive(LaunchInfo.GetArchiveCachePath(discInfo.Disc), discInfo.Disc).FirstOrDefault());
+                    filePaths.Add(discInfo.ApplicationId, ListCacheArchive(LaunchInfo.GetArchiveCachePath(discInfo.ApplicationId), discInfo.Disc).FirstOrDefault());
                 }
 
                 foreach (var discInfo in LaunchInfo.Game.Discs)
@@ -140,7 +140,7 @@ namespace ArchiveCacheManager
                     List<string> multiDiscPaths = new List<string>();
                     foreach (var path in filePaths)
                     {
-                        if (discInfo.Disc == path.Key)
+                        if (discInfo.ApplicationId == path.Key)
                         {
                             multiDiscPaths.Insert(0, path.Value);
                         }
@@ -150,7 +150,7 @@ namespace ArchiveCacheManager
                         }
                     }
 
-                    string m3uPath = LaunchInfo.GetM3uPath(LaunchInfo.GetArchiveCachePath(discInfo.Disc), discInfo.Disc);
+                    string m3uPath = LaunchInfo.GetM3uPath(LaunchInfo.GetArchiveCachePath(discInfo.ApplicationId), discInfo.ApplicationId);
                     try
                     {
                         File.WriteAllLines(m3uPath, multiDiscPaths);
@@ -225,7 +225,7 @@ namespace ArchiveCacheManager
                 if (LaunchInfo.Game.MultiDisc && LaunchInfo.MultiDiscSupport && LaunchInfo.Game.EmulatorPlatformM3u)
                 {
                     // This is a multi-disc game, and the emulator supports m3u files. Set the file list to the generated m3u file.
-                    fileList.Add(LaunchInfo.GetM3uPath(LaunchInfo.GetArchiveCacheLaunchPath(LaunchInfo.Game.SelectedDisc), LaunchInfo.Game.SelectedDisc));
+                    fileList.Add(LaunchInfo.GetM3uPath(LaunchInfo.GetArchiveCacheLaunchPath(LaunchInfo.Game.SelectedDiscApp), LaunchInfo.Game.SelectedDiscApp));
                 }
                 else
                 {
@@ -393,7 +393,7 @@ namespace ArchiveCacheManager
                     List<string> dirsToExclude = new List<string>();
                     foreach (var disc in LaunchInfo.Game.Discs)
                     {
-                        dirsToExclude.Add(LaunchInfo.GetArchiveCachePath(disc.Disc));
+                        dirsToExclude.Add(LaunchInfo.GetArchiveCachePath(disc.ApplicationId));
                     }
                     dirs = dirs.Except(dirsToExclude).ToArray();
                 }
@@ -480,7 +480,7 @@ namespace ArchiveCacheManager
                     string dest = string.Empty;
                     foreach (var discInfo in LaunchInfo.Game.Discs)
                     {
-                        dest = PathUtils.GetArchiveCachePlaytimePath(LaunchInfo.GetArchiveCachePath(discInfo.Disc));
+                        dest = PathUtils.GetArchiveCachePlaytimePath(LaunchInfo.GetArchiveCachePath(discInfo.ApplicationId));
                         if (!string.Equals(lastPlayedPath, dest, StringComparison.InvariantCultureIgnoreCase))
                         {
                             File.Copy(lastPlayedPath, dest, true);
@@ -514,7 +514,7 @@ namespace ArchiveCacheManager
                     DiskUtils.DeleteDirectory(launchPath, true, true);
 
                     string[] managerFiles = PathUtils.GetManagerFiles(LaunchInfo.GetArchiveCachePath());
-                    
+
                     foreach (var dir in Directory.GetDirectories(LaunchInfo.GetArchiveCachePath(), "*", SearchOption.AllDirectories))
                     {
                         string relativeDir = PathUtils.GetRelativePath(LaunchInfo.GetArchiveCachePath(), dir);

--- a/src/Core/GameInfo.cs
+++ b/src/Core/GameInfo.cs
@@ -23,11 +23,11 @@ namespace ArchiveCacheManager
         private bool mEmulatorPlatformM3u = false;
         private bool mMultiDisc = false;
         private int mTotalDiscs = 0;
-        private int mSelectedDisc = 0;
+        private string mSelectedDiscApp = string.Empty;
         private List<DiscInfo> mDiscs = new List<DiscInfo>();
 
         private static readonly string gameSection = "Game";
-        private static readonly string discSection = "Disc";
+        private static readonly string discSection = "DiscApp";
 
         /// <summary>
         /// True if GameInfo is loaded and valid, False otherwise.
@@ -96,10 +96,10 @@ namespace ArchiveCacheManager
             get => mTotalDiscs;
             set => mTotalDiscs = value;
         }
-        public int SelectedDisc
+        public string SelectedDiscApp
         {
-            get => mSelectedDisc;
-            set => mSelectedDisc = value;
+            get => mSelectedDiscApp;
+            set => mSelectedDiscApp = value;
         }
         public List<DiscInfo> Discs
         {
@@ -129,7 +129,7 @@ namespace ArchiveCacheManager
             mEmulatorPlatformM3u = game.mEmulatorPlatformM3u;
             mMultiDisc = game.mMultiDisc;
             mTotalDiscs = game.mTotalDiscs;
-            mSelectedDisc = game.mSelectedDisc;
+            mSelectedDiscApp = game.mSelectedDiscApp;
             mDiscs = new List<DiscInfo>(game.mDiscs);
         }
 
@@ -160,7 +160,7 @@ namespace ArchiveCacheManager
                     mEmulatorPlatformM3u = Convert.ToBoolean(iniData[gameSection][nameof(EmulatorPlatformM3u)]);
                     mMultiDisc = Convert.ToBoolean(iniData[gameSection][nameof(MultiDisc)]);
                     mTotalDiscs = Convert.ToInt32(iniData[gameSection][nameof(TotalDiscs)]);
-                    mSelectedDisc = Convert.ToInt32(iniData[gameSection][nameof(SelectedDisc)]);
+                    mSelectedDiscApp = iniData[gameSection][nameof(SelectedDiscApp)];
 
                     foreach (SectionData sectionData in iniData.Sections)
                     {
@@ -221,11 +221,12 @@ namespace ArchiveCacheManager
                 if (mMultiDisc)
                 {
                     iniData[gameSection][nameof(TotalDiscs)] = mTotalDiscs.ToString();
-                    iniData[gameSection][nameof(SelectedDisc)] = mSelectedDisc.ToString();
+                    iniData[gameSection][nameof(SelectedDiscApp)] = mSelectedDiscApp;
 
                     foreach (DiscInfo discInfo in mDiscs)
                     {
-                        string discNumberSection = string.Format("{0}{1}", discSection, discInfo.Disc);
+                        // Save as [DiscApp {ApplicationId}] to ensure that each section has a unique name
+                        string discNumberSection = string.Format("{0} {1}", discSection, discInfo.ApplicationId);
 
                         iniData[discNumberSection][nameof(DiscInfo.ApplicationId)] = discInfo.ApplicationId;
                         iniData[discNumberSection][nameof(DiscInfo.ArchivePath)] = discInfo.ArchivePath;

--- a/src/Plugin/GameLaunching.cs
+++ b/src/Plugin/GameLaunching.cs
@@ -147,10 +147,10 @@ namespace ArchiveCacheManager
             if (gameInfo.MultiDisc)
             {
                 Logger.Log("Multi-disc game detected.");
-                var (totalDiscs, selectedDisc, discs) = PluginUtils.GetMultiDiscInfo(game, app);
+                var (totalDiscs, selectedDiscApp, discs) = PluginUtils.GetMultiDiscInfo(game, app);
 
                 gameInfo.TotalDiscs = totalDiscs;
-                gameInfo.SelectedDisc = selectedDisc;
+                gameInfo.SelectedDiscApp = selectedDiscApp;
                 gameInfo.Discs = discs;
             }
             gameInfo.Save();

--- a/src/Plugin/PluginUtils.cs
+++ b/src/Plugin/PluginUtils.cs
@@ -76,7 +76,7 @@ namespace ArchiveCacheManager
         {
             var additionalApps = game.GetAllAdditionalApplications();
 
-            return Array.Exists(additionalApps, a => a.Disc != null && a.ApplicationPath == game.ApplicationPath);
+            return Array.Exists(additionalApps, a => a.Disc != null && PathUtils.ComparePaths(a.ApplicationPath, game.ApplicationPath));
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace ArchiveCacheManager
 
         /// <summary>
         /// Get info on a multi-disc game.
-        /// 
+        ///
         /// totalDiscs is the total number of discs in a game. Determined by counting additional apps with Disc property set. Will be 0 if not a multi-dsc game.
         /// selectedDisc is the selected disc, based on the additional app Disc property. Will be 1 if additional app is null, and 0 if not a multi-disc game.
         /// discs is a list of discs and associated info in disc order. Will be empty if not a multi-disc game.
@@ -142,7 +142,7 @@ namespace ArchiveCacheManager
             }
             else
             {
-                selectedDisc = (int)Array.Find(discApps, a => a.ApplicationPath == game.ApplicationPath).Disc;
+                selectedDisc = (int)Array.Find(discApps, a => PathUtils.ComparePaths(a.ApplicationPath, game.ApplicationPath)).Disc;
             }
 
             totalDiscs = discs.Count;

--- a/src/Plugin/PluginUtils.cs
+++ b/src/Plugin/PluginUtils.cs
@@ -104,22 +104,21 @@ namespace ArchiveCacheManager
         /// Get info on a multi-disc game.
         ///
         /// totalDiscs is the total number of discs in a game. Determined by counting additional apps with Disc property set. Will be 0 if not a multi-dsc game.
-        /// selectedDisc is the selected disc, based on the additional app Disc property. Will be 1 if additional app is null, and 0 if not a multi-disc game.
+        /// selectedDiscApp is the selected disc, based on the additional app Disc property. Will be 1 if additional app is null, and 0 if not a multi-disc game.
         /// discs is a list of discs and associated info in disc order. Will be empty if not a multi-disc game.
         /// </summary>
         /// <param name="game"></param>
         /// <param name="app"></param>
-        /// <returns>Tuple of (totalDiscs, selectedDisc, discs).</returns>
-        public static (int, int, List<DiscInfo>) GetMultiDiscInfo(IGame game, IAdditionalApplication app)
+        /// <returns>Tuple of (totalDiscs, selectedDiscApp, discs).</returns>
+        public static (int, string, List<DiscInfo>) GetMultiDiscInfo(IGame game, IAdditionalApplication app)
         {
             int totalDiscs = 0;
-            int selectedDisc = 0;
+            string selectedDiscApp = string.Empty;
             List<DiscInfo> discs = new List<DiscInfo>();
 
             if (!IsLaunchedGameMultiDisc(game, app))
             {
                 totalDiscs = 0;
-                selectedDisc = 0;
                 discs.Clear();
             }
 
@@ -138,16 +137,16 @@ namespace ArchiveCacheManager
 
             if (app != null)
             {
-                selectedDisc = (int)app.Disc;
+                selectedDiscApp = app.Id;
             }
             else
             {
-                selectedDisc = (int)Array.Find(discApps, a => PathUtils.ComparePaths(a.ApplicationPath, game.ApplicationPath)).Disc;
+                selectedDiscApp = Array.Find(discApps, a => PathUtils.ComparePaths(a.ApplicationPath, game.ApplicationPath)).Id;
             }
 
             totalDiscs = discs.Count;
 
-            return (totalDiscs, selectedDisc, discs);
+            return (totalDiscs, selectedDiscApp, discs);
         }
 
         public static IAdditionalApplication GetAdditionalApplicationById(string gameId, string appId)


### PR DESCRIPTION
Merge m3u related bug fixes
- Fix multi-disc path checks -> resolve paths during comparisons
- Fix overwriting of discs when multiple discs share the same disc number for a game
- Fix .m3u generation to list selected disc first, then sort remaining by disc number and original order to match LaunchBox behavior
- Prevent exception when duplicate archive paths exist during .m3u generation