### PR TITLE
Fix filename sanitization

### DIFF
--- a/src/Core/LaunchInfo.cs
+++ b/src/Core/LaunchInfo.cs
@@ -406,13 +406,13 @@ namespace ArchiveCacheManager
             switch (mGameCacheData.Config.LaunchPath)
             {
                 case Config.LaunchPath.Title:
-                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidPath(mGame.Title, "Title"));
+                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidFileName(mGame.Title, "Title"));
                     break;
                 case Config.LaunchPath.Platform:
-                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidPath(mGame.Platform, "Platform"));
+                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidFileName(mGame.Platform, "Platform"));
                     break;
                 case Config.LaunchPath.Emulator:
-                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidPath(mGame.Emulator, "Emulator"));
+                    launchPath = Path.Combine(PathUtils.CachePath(), PathUtils.GetValidFileName(mGame.Emulator, "Emulator"));
                     break;
                 case Config.LaunchPath.Default:
                 default:


### PR DESCRIPTION
- Correct windows reserved file names list (https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/FileIO/naming-a-file.md)
- Use full set of invalid characters (GetInvalidPathChars -> Path.GetInvalidFileNameChars)
- Correct final check for determining if the name is valid (directoryInfo -> Path.GetFullPath)
- Check for empty/whitespace filenames