### PR TITLE
Link directory fixes

### DIFF
--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -197,12 +197,26 @@ namespace ArchiveCacheManager
                     }
                     else
                     {
-                        GameInfo gameInfo = new GameInfo(Path.Combine(dir, PathUtils.GetGameInfoFileName()));
+                        GameInfo gameInfo = new GameInfo(gameInfoPath);
                         if (!gameInfo.InfoLoaded)
                         {
+                            try
+                            {
+                                var linkSource = File.ReadAllText(Path.Combine(dir, PathUtils.GetLinkFlagFileName()));
+                                if (!string.IsNullOrEmpty(linkSource))
+                                {
+                                    gameInfo = new GameInfo(Path.Combine(linkSource, PathUtils.GetGameInfoFileName()));
+                                    if (gameInfo.InfoLoaded)
+                                        continue; // don't setup decompress size for link directories
+                                }
+                            }
+                            catch
+                            {
+                            }
+
                             Logger.Log(string.Format("Error loading game.ini, deleting cached item \"{0}\".", dir));
                             DiskUtils.DeleteDirectory(dir, false, true);
-                            continue;
+                            continue; // don't setup decompress size for deleted directories
                         }
 
                         if (gameInfo.DecompressedSize == 0)

--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -437,7 +437,7 @@ namespace ArchiveCacheManager
                         if (!gameInfo.KeepInCache || deleteKeep)
                         {
                             Logger.Log(string.Format("Deleting cached item \"{0}\".", dirs[i]));
-                            DiskUtils.DeleteDirectory(dirs[i]);
+                            DiskUtils.DeleteDirectory(dirs[i], false, true);
                             deletedSize += gameInfo.DecompressedSize;
 
                             if (deletedSize > sizeToDelete)

--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -202,10 +202,10 @@ namespace ArchiveCacheManager
                         {
                             try
                             {
-                                var linkSource = File.ReadAllText(Path.Combine(dir, PathUtils.GetLinkFlagFileName()));
-                                if (!string.IsNullOrEmpty(linkSource))
+                                var archiveCachePath = File.ReadAllText(Path.Combine(dir, PathUtils.GetLinkFlagFileName()));
+                                if (!string.IsNullOrEmpty(archiveCachePath))
                                 {
-                                    gameInfo = new GameInfo(Path.Combine(linkSource, PathUtils.GetGameInfoFileName()));
+                                    gameInfo = new GameInfo(Path.Combine(archiveCachePath, PathUtils.GetGameInfoFileName()));
                                     if (gameInfo.InfoLoaded)
                                         continue; // don't setup decompress size for link directories
                                 }

--- a/src/Core/DiskUtils.cs
+++ b/src/Core/DiskUtils.cs
@@ -31,28 +31,32 @@ namespace ArchiveCacheManager
                     {
                     }
 
-                    // Enumerate and delete all files in all subdirectories
-                    foreach (string filePath in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+                    static void DeleteDirectoryTree(string path, bool contentsOnly)
                     {
-                        // Clear any read-only or other special file attributes.
-                        File.SetAttributes(filePath, FileAttributes.Normal);
-                        File.Delete(filePath);
-                    }
-                    // Enumerate and delete all subdirectories
-                    foreach (string dirPath in Directory.EnumerateDirectories(path))
-                    {
-                        Directory.Delete(dirPath, true);
+                        // Enumerate and delete all files in all subdirectories
+                        foreach (string filePath in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+                        {
+                            // Clear any read-only or other special file attributes.
+                            File.SetAttributes(filePath, FileAttributes.Normal);
+                            File.Delete(filePath);
+                        }
+                        // Enumerate and delete all subdirectories
+                        foreach (string dirPath in Directory.EnumerateDirectories(path))
+                        {
+                            Directory.Delete(dirPath, true);
+                        }
+
+                        if (!contentsOnly)
+                        {
+                            Directory.Delete(path, true);
+                        }
                     }
 
-                    if (!contentsOnly)
-                    {
-                        Directory.Delete(path, true);
-                    }
+                    DeleteDirectoryTree(path, contentsOnly);
 
                     if (!string.IsNullOrEmpty(linkSource) && unlink)
                     {
-                        SetDirectoryContentsReadOnly(linkSource);
-                        File.Delete(PathUtils.GetArchiveCacheLinkFlagPath(linkSource));
+                        DeleteDirectoryTree(linkSource, contentsOnly);
                     }
                 }
             }

--- a/src/Core/PathUtils.cs
+++ b/src/Core/PathUtils.cs
@@ -44,6 +44,7 @@ namespace ArchiveCacheManager
         private static readonly string configFileName = @"config.ini";
         private static readonly string gameIndexFileName = @"game-index.ini";
         private static readonly string gameInfoFileName = @"game.ini";
+        private static readonly string linkFlagFileName = @"link";
         private static readonly string default7zFileName = @"7z.exe";
         private static readonly string alt7zFileName = @"7-zip.exe";
         private static readonly string tempPath = @"Temp";
@@ -270,7 +271,7 @@ namespace ArchiveCacheManager
         /// </summary>
         /// <param name="archiveLaunchPath">Location of the launch path in the cache.</param>
         /// <returns>Absolute path to the link flag file.</returns>
-        public static string GetArchiveCacheLinkFlagPath(string archiveLaunchPath) => Path.Combine(archiveLaunchPath, "link");
+        public static string GetArchiveCacheLinkFlagPath(string archiveLaunchPath) => Path.Combine(archiveLaunchPath, linkFlagFileName);
 
         /// <summary>
         /// Absolute path to the m3u file for the given archive cache path. Filename includes the game ID.
@@ -330,6 +331,12 @@ namespace ArchiveCacheManager
         /// </summary>
         /// <returns></returns>
         public static string GetGameInfoFileName() => gameInfoFileName;
+
+        /// <summary>
+        /// Link flag filename.
+        /// </summary>
+        /// <returns></returns>
+        public static string GetLinkFlagFileName() => linkFlagFileName;
 
         /// <summary>
         /// Calculates an MD5 hash of the given path.

--- a/src/Plugin/NewConfigWindow.cs
+++ b/src/Plugin/NewConfigWindow.cs
@@ -354,7 +354,7 @@ namespace ArchiveCacheManager
             foreach (DataGridViewRow row in cacheDataGridView.SelectedRows)
             {
                 Logger.Log(string.Format("Manually deleting cached item \"{0}\".", row.Cells["ArchivePath"].Value));
-                DiskUtils.DeleteDirectory(row.Cells["ArchivePath"].Value.ToString());
+                DiskUtils.DeleteDirectory(row.Cells["ArchivePath"].Value.ToString(), false, true);
                 cacheDataGridView.Rows.Remove(row);
             }
 


### PR DESCRIPTION
- Don't valid link directories during cache integrity verification
- Delete corresponding link directory when clearing individual cache entries
- Delete link directories when clearing entire cache