### PR TITLE
Link directory fix redo

### DIFF
--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -437,7 +437,7 @@ namespace ArchiveCacheManager
                         if (!gameInfo.KeepInCache || deleteKeep)
                         {
                             Logger.Log(string.Format("Deleting cached item \"{0}\".", dirs[i]));
-                            DiskUtils.DeleteDirectory(dirs[i], false, true);
+                            DiskUtils.DeleteDirectory(dirs[i]);
                             deletedSize += gameInfo.DecompressedSize;
 
                             if (deletedSize > sizeToDelete)

--- a/src/Core/CacheManager.cs
+++ b/src/Core/CacheManager.cs
@@ -200,18 +200,12 @@ namespace ArchiveCacheManager
                         GameInfo gameInfo = new GameInfo(gameInfoPath);
                         if (!gameInfo.InfoLoaded)
                         {
-                            try
+                            var linkSource = PathUtils.ReadLinkSourceFromArchiveCache(dir);
+                            if (!string.IsNullOrEmpty(linkSource))
                             {
-                                var archiveCachePath = File.ReadAllText(Path.Combine(dir, PathUtils.GetLinkFlagFileName()));
-                                if (!string.IsNullOrEmpty(archiveCachePath))
-                                {
-                                    gameInfo = new GameInfo(Path.Combine(archiveCachePath, PathUtils.GetGameInfoFileName()));
-                                    if (gameInfo.InfoLoaded)
-                                        continue; // don't setup decompress size for link directories
-                                }
-                            }
-                            catch
-                            {
+                                gameInfo = new GameInfo(Path.Combine(linkSource, PathUtils.GetGameInfoFileName()));
+                                if (gameInfo.InfoLoaded)
+                                    continue; // don't setup decompress size for link directories
                             }
 
                             Logger.Log(string.Format("Error loading game.ini, deleting cached item \"{0}\".", dir));
@@ -437,7 +431,15 @@ namespace ArchiveCacheManager
                         if (!gameInfo.KeepInCache || deleteKeep)
                         {
                             Logger.Log(string.Format("Deleting cached item \"{0}\".", dirs[i]));
+
+                            var linkSource = PathUtils.ReadLinkSourceFromArchiveCache(dirs[i]);
+                            if (!string.IsNullOrEmpty(linkSource))
+                            {
+                                DiskUtils.DeleteDirectory(linkSource);
+                            }
+
                             DiskUtils.DeleteDirectory(dirs[i]);
+
                             deletedSize += gameInfo.DecompressedSize;
 
                             if (deletedSize > sizeToDelete)

--- a/src/Core/DiskUtils.cs
+++ b/src/Core/DiskUtils.cs
@@ -22,14 +22,7 @@ namespace ArchiveCacheManager
             {
                 if (Directory.Exists(path))
                 {
-                    string linkSource = string.Empty;
-                    try
-                    {
-                        linkSource = File.ReadAllText(PathUtils.GetArchiveCacheLinkFlagPath(path));
-                    }
-                    catch (Exception)
-                    {
-                    }
+                    string linkSource = PathUtils.ReadLinkSourceFromArchiveCache(path);
 
                     // Enumerate and delete all files in all subdirectories
                     foreach (string filePath in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))

--- a/src/Core/DiskUtils.cs
+++ b/src/Core/DiskUtils.cs
@@ -31,32 +31,28 @@ namespace ArchiveCacheManager
                     {
                     }
 
-                    static void DeleteDirectoryTree(string path, bool contentsOnly)
+                    // Enumerate and delete all files in all subdirectories
+                    foreach (string filePath in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
                     {
-                        // Enumerate and delete all files in all subdirectories
-                        foreach (string filePath in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
-                        {
-                            // Clear any read-only or other special file attributes.
-                            File.SetAttributes(filePath, FileAttributes.Normal);
-                            File.Delete(filePath);
-                        }
-                        // Enumerate and delete all subdirectories
-                        foreach (string dirPath in Directory.EnumerateDirectories(path))
-                        {
-                            Directory.Delete(dirPath, true);
-                        }
-
-                        if (!contentsOnly)
-                        {
-                            Directory.Delete(path, true);
-                        }
+                        // Clear any read-only or other special file attributes.
+                        File.SetAttributes(filePath, FileAttributes.Normal);
+                        File.Delete(filePath);
+                    }
+                    // Enumerate and delete all subdirectories
+                    foreach (string dirPath in Directory.EnumerateDirectories(path))
+                    {
+                        Directory.Delete(dirPath, true);
                     }
 
-                    DeleteDirectoryTree(path, contentsOnly);
+                    if (!contentsOnly)
+                    {
+                        Directory.Delete(path, true);
+                    }
 
                     if (!string.IsNullOrEmpty(linkSource) && unlink)
                     {
-                        DeleteDirectoryTree(linkSource, contentsOnly);
+                        SetDirectoryContentsReadOnly(linkSource);
+                        File.Delete(PathUtils.GetArchiveCacheLinkFlagPath(linkSource));
                     }
                 }
             }

--- a/src/Core/PathUtils.cs
+++ b/src/Core/PathUtils.cs
@@ -267,11 +267,32 @@ namespace ArchiveCacheManager
         public static string GetArchiveCacheExtractingFlagPath(string archiveCachePath) => Path.Combine(archiveCachePath, "extracting");
 
         /// <summary>
-        /// Absolute path to the link flag file for the given archive cache path.
+        /// Absolute path to the link flag file for the given archive launch or cache path.
         /// </summary>
-        /// <param name="archiveLaunchPath">Location of the launch path in the cache.</param>
+        /// <param name="archiveLaunchOrCachePath">Location of the archive launch or cache path in the cache.</param>
         /// <returns>Absolute path to the link flag file.</returns>
-        public static string GetArchiveCacheLinkFlagPath(string archiveLaunchPath) => Path.Combine(archiveLaunchPath, linkFlagFileName);
+        public static string GetArchiveCacheLinkFlagPath(string archiveLaunchOrCachePath) => Path.Combine(archiveLaunchOrCachePath, linkFlagFileName);
+
+        /// <summary>
+        /// Reads the contents of the link flag file located in the specified archive launch or cache path.
+        /// </summary>
+        /// <param name="archiveLaunchOrCachePath">Location of the archive launch or cache path in the cache.</param>
+        /// <returns>
+        /// The string contents of the link flag file, or an empty string if the file could not be read.
+        /// </returns>
+        public static string ReadLinkSourceFromArchiveCache(string archiveLaunchOrCachePath)
+        {
+            string linkSource = String.Empty;
+            try
+            {
+                linkSource = File.ReadAllText(GetArchiveCacheLinkFlagPath(archiveLaunchOrCachePath));
+            }
+            catch (Exception)
+            {
+            }
+
+            return linkSource;
+        }
 
         /// <summary>
         /// Absolute path to the m3u file for the given archive cache path. Filename includes the game ID.

--- a/src/Plugin/NewConfigWindow.cs
+++ b/src/Plugin/NewConfigWindow.cs
@@ -353,8 +353,14 @@ namespace ArchiveCacheManager
         {
             foreach (DataGridViewRow row in cacheDataGridView.SelectedRows)
             {
-                Logger.Log(string.Format("Manually deleting cached item \"{0}\".", row.Cells["ArchivePath"].Value));
-                DiskUtils.DeleteDirectory(row.Cells["ArchivePath"].Value.ToString());
+                var dir = row.Cells["ArchivePath"].Value.ToString();
+                Logger.Log(string.Format("Manually deleting cached item \"{0}\".", dir));
+
+                string linkSource = PathUtils.ReadLinkSourceFromArchiveCache(dir);
+                if (!string.IsNullOrEmpty(linkSource))
+                    DiskUtils.DeleteDirectory(linkSource);
+
+                DiskUtils.DeleteDirectory(dir);
                 cacheDataGridView.Rows.Remove(row);
             }
 

--- a/src/Plugin/NewConfigWindow.cs
+++ b/src/Plugin/NewConfigWindow.cs
@@ -354,7 +354,7 @@ namespace ArchiveCacheManager
             foreach (DataGridViewRow row in cacheDataGridView.SelectedRows)
             {
                 Logger.Log(string.Format("Manually deleting cached item \"{0}\".", row.Cells["ArchivePath"].Value));
-                DiskUtils.DeleteDirectory(row.Cells["ArchivePath"].Value.ToString(), false, true);
+                DiskUtils.DeleteDirectory(row.Cells["ArchivePath"].Value.ToString());
                 cacheDataGridView.Rows.Remove(row);
             }
 


### PR DESCRIPTION
Delete link directories when clearing individual cache entries or all cache entries
- Revert 4f39659
- Correct GetArchiveCacheLinkFlagPath documentation and parameter names
-  Add ReadLinkSourceFromArchiveCache API
- replace inline code with API in VerifyCacheIntegrity
- replace inline code with API in DeleteDirectory
-  Check for link source and delete linked directories in ClearCacheSpace
-  Check for link source and delete linked directories in deleteSelectedButton_Click